### PR TITLE
Passing selectedItem along new text to the delegate

### DIFF
--- a/MJAutoComplete/MJAutoCompleteManager.h
+++ b/MJAutoComplete/MJAutoCompleteManager.h
@@ -43,6 +43,9 @@ typedef void(^MJAutoCompleteListCallback)(NSArray* list);
          shouldUpdateToText:(NSString *)newText;
 
 @optional
+- (void)autoCompleteManager:(MJAutoCompleteManager *)acManager
+         shouldUpdateToText:(NSString *)newText
+               selectedItem:(MJAutoCompleteItem *)selectedItem;
 /** For the sake of lazy loading, we notify the delegate when an autoComplete cell will be presented, so the developer can postpone fetching the image until the cell is actually going to be presented to the user. **/
 - (void)autoCompleteManager:(MJAutoCompleteManager *)acManager
             willPresentCell:(id)autoCompleteCell

--- a/MJAutoComplete/MJAutoCompleteManager.m
+++ b/MJAutoComplete/MJAutoCompleteManager.m
@@ -167,11 +167,16 @@
     NSString* prevString = [self.processingString substringToIndex:index];
     NSString* newString = [NSString stringWithFormat:@"%@%@ ", prevString, autoCompleteString];
     
-    [self.delegate autoCompleteManager:self shouldUpdateToText:newString];
+    if ([self.delegate respondsToSelector:@selector(autoCompleteManager:shouldUpdateToText:selectedItem:)]) {
+        
+        [self.delegate autoCompleteManager:self shouldUpdateToText:newString selectedItem:selectedItem];
+        
+    } else {
+     
+        [self.delegate autoCompleteManager:self shouldUpdateToText:newString];
+    }
     // process new string:
     [self processString:newString];
 }
-
-#pragma mark -
 
 @end


### PR DESCRIPTION
Hi,

I added an optional protocol method to retrieve new text **and** selected item, as I needed information from the context dictionary along with the autocomplete string. The manager also check safely if the new method is implemented otherwise it calls the mandatory protocol method.
