### PR TITLE
Changed trigger's break set to alphanumeric set

### DIFF
--- a/MJAutoComplete/MJAutoCompleteTrigger.m
+++ b/MJAutoComplete/MJAutoCompleteTrigger.m
@@ -41,7 +41,7 @@
     }
 
     // make sure to search backwards, since that's where the user it typing
-    NSCharacterSet *breakSet = [[NSCharacterSet letterCharacterSet] invertedSet];
+    NSCharacterSet *breakSet = [[NSCharacterSet alphanumericCharacterSet] invertedSet];
     NSRange brRange = [string rangeOfCharacterFromSet:breakSet
                                               options:NSBackwardsSearch];
     


### PR DESCRIPTION
Allows for autocompleting things like usernames which might even start with a number.

Needed it for the project I'm working on, but that means I can't use it as a pod unless this gets added to the official repo or setup my own podspec.  Thought it also might help others who use/would use this library.

Thanks again for this tool!
